### PR TITLE
Edit reponsiveness calculation to eliminate really high outliers

### DIFF
--- a/src/irmMetric.ts
+++ b/src/irmMetric.ts
@@ -122,11 +122,10 @@ export async function fetchRepoIssues(owner: string, name: string) {
  */
 export function calculateIRM(issues: IssueNode[]) {
   let totalResponseTime = 0;
-  let issueCount = 0;
 
   issues.forEach(issue => {
     const createdAt = parseISO(issue.node.createdAt);
-    let responseTime = null;
+    let responseTime = 0;
 
     // Check if there was a comment, otherwise use closedAt
     if (issue.node.comments.nodes.length > 0) {
@@ -137,18 +136,16 @@ export function calculateIRM(issues: IssueNode[]) {
       responseTime = differenceInMinutes(closedAt, createdAt);
     }
 
-    if (responseTime !== null) {
+    if (responseTime < maxResponseTime) {
       totalResponseTime += responseTime;
-      issueCount++;
     }
     //else add the maxResponseTime
-    else{
+    else {
       totalResponseTime += maxResponseTime;
-      issueCount++;
     }
   });
 
-  const averageResponseTime = issueCount > 0 ? totalResponseTime / issueCount : 0; //
+  const averageResponseTime = issues.length > 0 ? totalResponseTime / issues.length : 0; //
 
   logMessage('DEBUG', `Calculated IRM (Average Issue Response Time): ${averageResponseTime} minutes`);
   
@@ -194,9 +191,9 @@ export function normalizeIRM (averageResponseTime: number, maxResponseTime: numb
 export async function getIRM(owner: string, repo: string): Promise<number> {
   const issues = await fetchRepoIssues(owner, repo);
 
-  
   const irmScore = calculateIRM(issues);
-  return parseFloat(irmScore.toFixed(3));
 
-  
+  logMessage('INFO', `Final IRM Score: ${irmScore}`);
+
+  return parseFloat(irmScore.toFixed(3));
 }


### PR DESCRIPTION
The current calculation for responsive maintainers averages the time it took for a maintainer to comment on or close an issue and standardized it into a score between 0 and 1. This score would often be 0 because some of the response times were a lot higher than the max response time of 28 days, skewing the averages higher than the max response time, and causing the score to be zero. This pull request standardizes all of these high values to be the max response time in order to maintain the response time data that is between 0 and 28 days.